### PR TITLE
Fix build failed multiple-value uuid.NewV4() in single-value context

### DIFF
--- a/crontab/crontab.go
+++ b/crontab/crontab.go
@@ -456,7 +456,7 @@ func uncomment(line string) string {
 func parseKronJob(line string, template string) KronJob {
 	slices := strings.Split(line, "#")
 	cronjob := slices[0]
-	name := uuid.NewV4().String()
+	name := uuid.Must(uuid.NewV4()).String()
 	if len(slices) > 1 {
 		config, err := parseNameYaml(slices[1])
 		if err == nil {


### PR DESCRIPTION
**issue**
uuid.NewV4 in satori/go.uuid has changed return values to multiple-value(uuid, error)
https://godoc.org/github.com/satori/go.uuid#NewV4

so, I fixed returnes single-value using uuid.Must which is helper as backward compatibility.
https://godoc.org/github.com/satori/go.uuid#Must

**testing**
before:
```
$make build
building krontab
GOPATH=/Users/u5surf/go
go build -ldflags "-X github.com/jacobtomlinson/krontab/version.GitCommit=e88f229b1ebbf8e56f60a9e18197e2fa69ac2cdd -X github.com/jacobtomlinson/krontab/version.BuildDate=2019-03-01-09:30:36 -X github.com/jacobtomlinson/krontab/version.Version=v0.1.6-2-ge88f229" -o bin/krontab
# github.com/jacobtomlinson/krontab/crontab
crontab/crontab.go:459:20: multiple-value uuid.NewV4() in single-value context
make: *** [build] Error 2
```

after:
```
$make build
building krontab
GOPATH=/Users/u5surf/go
go build -ldflags "-X github.com/jacobtomlinson/krontab/version.GitCommit=e88f229b1ebbf8e56f60a9e18197e2fa69ac2cdd+CHANGES -X github.com/jacobtomlinson/krontab/version.BuildDate=2019-03-01-09:32:39 -X github.com/jacobtomlinson/krontab/version.Version=v0.1.6-2-ge88f229-dirty" -o bin/krontab
```